### PR TITLE
Accept a timeout of any duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,22 +274,22 @@ impl Manager {
     }
 
     /// Set timeout for when waiting for a connection object to become available.
-    pub fn wait_timeout<T: Into<f64> + Copy>(mut self, value: T) -> Self {
-        self.pool_config.timeouts.wait = Some(Duration::from_secs_f64(value.into()));
+    pub fn wait_timeout(mut self, value: Duration) -> Self {
+        self.pool_config.timeouts.wait = Some(value);
         self.set_runtime(Runtime::Tokio1);
         self
     }
 
     /// Set timeout for when creating a new connection object.
-    pub fn create_timeout<T: Into<f64> + Copy>(mut self, value: T) -> Self {
-        self.pool_config.timeouts.create = Some(Duration::from_secs_f64(value.into()));
+    pub fn create_timeout(mut self, value: Duration) -> Self {
+        self.pool_config.timeouts.create = Some(value);
         self.set_runtime(Runtime::Tokio1);
         self
     }
 
     /// Set timeout for when recycling a connection object.
-    pub fn recycle_timeout<T: Into<f64> + Copy>(mut self, value: T) -> Self {
-        self.pool_config.timeouts.recycle = Some(Duration::from_secs_f64(value.into()));
+    pub fn recycle_timeout(mut self, value: Duration) -> Self {
+        self.pool_config.timeouts.recycle = Some(value);
         self.set_runtime(Runtime::Tokio1);
         self
     }

--- a/tests/unitest.rs
+++ b/tests/unitest.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use tokio;
     use deadpool_tiberius::SqlServerResult;
     use futures_lite::stream::StreamExt;
@@ -14,7 +16,7 @@ mod tests {
                 .database("database")
                 .trust_cert()
                 .max_size(10)
-                .wait_timeout(1.52)  // in seconds, default to no timeout
+                .wait_timeout(Duration::from_secs_f64(1.52))
                 .pre_recycle_sync(|_client, _metrics| {
                     // do sth with client object and pool metrics
                     Ok(())


### PR DESCRIPTION
I would find it helpful to accept a timeout of any duration, rather than passing in an `f64` for the number of seconds. This pull request should achieve that.

I can't run the tests myself (I don't have SQL Server installed locally and I don't want to change the connection parameters of the tests), so you might wanna double check and make sure they still pass. I don't see why they wouldn't.